### PR TITLE
Idjohnson patch 1 user level description

### DIFF
--- a/cmd/user.go
+++ b/cmd/user.go
@@ -148,13 +148,13 @@ func init() {
 	updateUserCmd.Flags().StringVarP(&email, "email", "e", "", "E-Mail address of the user")
 	updateUserCmd.Flags().StringVarP(&displayName, "displayname", "j", "", "Display name of the user")
 	updateUserCmd.Flags().StringVarP(&password, "password", "p", "", "Password of the user")
-	updateUserCmd.Flags().StringVarP(&accessLevel, "accesslevel", "a", "", "AccessLeve of the user")
+	updateUserCmd.Flags().StringVarP(&accessLevel, "accesslevel", "a", "", "AccessLevel of the user. Valid values are READER, USER, or ADMIN.")
 
 	userCmd.AddCommand(addUserCmd)
 	addUserCmd.Flags().StringVarP(&email, "email", "e", "", "E-Mail address of the new user")
 	addUserCmd.Flags().StringVarP(&displayName, "displayname", "j", "", "Display name of the new user")
 	addUserCmd.Flags().StringVarP(&password, "password", "p", "", "Password of the new user")
-	addUserCmd.Flags().StringVarP(&accessLevel, "accesslevel", "a", "", "AccessLeve of the new user")
+	addUserCmd.Flags().StringVarP(&accessLevel, "accesslevel", "a", "", "AccessLevel of the new user.  Valid values are READER, USER, or ADMIN.")
 
 	userCmd.AddCommand(deleteUserCmd)
 	deleteUserCmd.Flags().StringVarP(&userId, "userid", "u", "", "UserId of the user")

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -148,13 +148,13 @@ func init() {
 	updateUserCmd.Flags().StringVarP(&email, "email", "e", "", "E-Mail address of the user")
 	updateUserCmd.Flags().StringVarP(&displayName, "displayname", "j", "", "Display name of the user")
 	updateUserCmd.Flags().StringVarP(&password, "password", "p", "", "Password of the user")
-	updateUserCmd.Flags().StringVarP(&accessLevel, "accesslevel", "a", "", "AccessLevel of the user. Valid values are READER, USER, or ADMIN.")
+	updateUserCmd.Flags().StringVarP(&accessLevel, "accesslevel", "a", "", "AccessLevel of the user: valid values are READER, USER, or ADMIN")
 
 	userCmd.AddCommand(addUserCmd)
 	addUserCmd.Flags().StringVarP(&email, "email", "e", "", "E-Mail address of the new user")
 	addUserCmd.Flags().StringVarP(&displayName, "displayname", "j", "", "Display name of the new user")
 	addUserCmd.Flags().StringVarP(&password, "password", "p", "", "Password of the new user")
-	addUserCmd.Flags().StringVarP(&accessLevel, "accesslevel", "a", "", "AccessLevel of the new user.  Valid values are READER, USER, or ADMIN.")
+	addUserCmd.Flags().StringVarP(&accessLevel, "accesslevel", "a", "", "AccessLevel of the new user: valid values are READER, USER, or ADMIN")
 
 	userCmd.AddCommand(deleteUserCmd)
 	deleteUserCmd.Flags().StringVarP(&userId, "userid", "u", "", "UserId of the user")

--- a/punq.json
+++ b/punq.json
@@ -1,14 +1,14 @@
 {
-    "version": "1.4.2",
+    "version": "1.4.3",
     "license": "MIT",
     "homepage": "https://punq.dev",
     "bin": "punq.exe",
-    "pre_install": "Rename-Item \"$dir\\punq-v1.4.2-windows-amd64\" punq.exe",
+    "pre_install": "Rename-Item \"$dir\\punq-v1.4.3-windows-amd64\" punq.exe",
     "description": "A slim open-source workload manager for Kubernetes with team collaboration, WebApp, and CLI.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mogenius/punq/releases/download/v1.4.2/punq-v1.4.2-windows-amd64",
-            "hash": "1bc0c80d72c1e1bb898e06bfbf9191a3951ee16d1e61c92abb9d7552820f1534"
+            "url": "https://github.com/mogenius/punq/releases/download/v1.4.3/punq-v1.4.3-windows-amd64",
+            "hash": "f0c0cfc4ebca972984d6b8e83c2c43760f14eb450ce59cd17a29161e9e8671da"
         }
     }
 }

--- a/punq.json
+++ b/punq.json
@@ -1,14 +1,14 @@
 {
-    "version": "1.4.7",
+    "version": "1.4.8",
     "license": "MIT",
     "homepage": "https://punq.dev",
     "bin": "punq.exe",
-    "pre_install": "Rename-Item \"$dir\\punq-v1.4.7-windows-amd64\" punq.exe",
+    "pre_install": "Rename-Item \"$dir\\punq-v1.4.8-windows-amd64\" punq.exe",
     "description": "A slim open-source workload manager for Kubernetes with team collaboration, WebApp, and CLI.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mogenius/punq/releases/download/v1.4.7/punq-v1.4.7-windows-amd64",
-            "hash": "f82cb99b0d4292f79a2609927415df82e425a2e64a6f3c65cf5f9731357f2689"
+            "url": "https://github.com/mogenius/punq/releases/download/v1.4.8/punq-v1.4.8-windows-amd64",
+            "hash": "093371c31fa827a6157c962dc2d23e65e5dba6004f8964c4f76869215dd35d4c"
         }
     }
 }

--- a/punq.json
+++ b/punq.json
@@ -1,14 +1,14 @@
 {
-    "version": "1.4.1",
+    "version": "1.4.2",
     "license": "MIT",
     "homepage": "https://punq.dev",
     "bin": "punq.exe",
-    "pre_install": "Rename-Item \"$dir\\punq-v1.4.1-windows-amd64\" punq.exe",
+    "pre_install": "Rename-Item \"$dir\\punq-v1.4.2-windows-amd64\" punq.exe",
     "description": "A slim open-source workload manager for Kubernetes with team collaboration, WebApp, and CLI.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mogenius/punq/releases/download/v1.4.1/punq-v1.4.1-windows-amd64",
-            "hash": "bc55b518d0bc084532b6c2973b4ca61958281a7fb648f7a134b430d2c696dd3d"
+            "url": "https://github.com/mogenius/punq/releases/download/v1.4.2/punq-v1.4.2-windows-amd64",
+            "hash": "1bc0c80d72c1e1bb898e06bfbf9191a3951ee16d1e61c92abb9d7552820f1534"
         }
     }
 }

--- a/punq.json
+++ b/punq.json
@@ -1,14 +1,14 @@
 {
-    "version": "1.4.3",
+    "version": "1.4.4",
     "license": "MIT",
     "homepage": "https://punq.dev",
     "bin": "punq.exe",
-    "pre_install": "Rename-Item \"$dir\\punq-v1.4.3-windows-amd64\" punq.exe",
+    "pre_install": "Rename-Item \"$dir\\punq-v1.4.4-windows-amd64\" punq.exe",
     "description": "A slim open-source workload manager for Kubernetes with team collaboration, WebApp, and CLI.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mogenius/punq/releases/download/v1.4.3/punq-v1.4.3-windows-amd64",
-            "hash": "f0c0cfc4ebca972984d6b8e83c2c43760f14eb450ce59cd17a29161e9e8671da"
+            "url": "https://github.com/mogenius/punq/releases/download/v1.4.4/punq-v1.4.4-windows-amd64",
+            "hash": "47b6368da345d7b979e5d0fb08ea591f1347212c82b7d93b94812617e62db2fe"
         }
     }
 }

--- a/punq.json
+++ b/punq.json
@@ -1,14 +1,14 @@
 {
-    "version": "1.4.5",
+    "version": "1.4.6",
     "license": "MIT",
     "homepage": "https://punq.dev",
     "bin": "punq.exe",
-    "pre_install": "Rename-Item \"$dir\\punq-v1.4.5-windows-amd64\" punq.exe",
+    "pre_install": "Rename-Item \"$dir\\punq-v1.4.6-windows-amd64\" punq.exe",
     "description": "A slim open-source workload manager for Kubernetes with team collaboration, WebApp, and CLI.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mogenius/punq/releases/download/v1.4.5/punq-v1.4.5-windows-amd64",
-            "hash": "8a1dbb113603b95c03b6c62a6d5ff257cc45fcce26699b3ef56b6fa867bf3e39"
+            "url": "https://github.com/mogenius/punq/releases/download/v1.4.6/punq-v1.4.6-windows-amd64",
+            "hash": "5997433ff247f67900edde125241247ab3bfe24a38b734ba4082f7836dc3ffe2"
         }
     }
 }

--- a/punq.json
+++ b/punq.json
@@ -1,14 +1,14 @@
 {
-    "version": "1.4.4",
+    "version": "1.4.5",
     "license": "MIT",
     "homepage": "https://punq.dev",
     "bin": "punq.exe",
-    "pre_install": "Rename-Item \"$dir\\punq-v1.4.4-windows-amd64\" punq.exe",
+    "pre_install": "Rename-Item \"$dir\\punq-v1.4.5-windows-amd64\" punq.exe",
     "description": "A slim open-source workload manager for Kubernetes with team collaboration, WebApp, and CLI.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mogenius/punq/releases/download/v1.4.4/punq-v1.4.4-windows-amd64",
-            "hash": "47b6368da345d7b979e5d0fb08ea591f1347212c82b7d93b94812617e62db2fe"
+            "url": "https://github.com/mogenius/punq/releases/download/v1.4.5/punq-v1.4.5-windows-amd64",
+            "hash": "8a1dbb113603b95c03b6c62a6d5ff257cc45fcce26699b3ef56b6fa867bf3e39"
         }
     }
 }

--- a/punq.json
+++ b/punq.json
@@ -1,14 +1,14 @@
 {
-    "version": "1.4.6",
+    "version": "1.4.7",
     "license": "MIT",
     "homepage": "https://punq.dev",
     "bin": "punq.exe",
-    "pre_install": "Rename-Item \"$dir\\punq-v1.4.6-windows-amd64\" punq.exe",
+    "pre_install": "Rename-Item \"$dir\\punq-v1.4.7-windows-amd64\" punq.exe",
     "description": "A slim open-source workload manager for Kubernetes with team collaboration, WebApp, and CLI.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mogenius/punq/releases/download/v1.4.6/punq-v1.4.6-windows-amd64",
-            "hash": "5997433ff247f67900edde125241247ab3bfe24a38b734ba4082f7836dc3ffe2"
+            "url": "https://github.com/mogenius/punq/releases/download/v1.4.7/punq-v1.4.7-windows-amd64",
+            "hash": "f82cb99b0d4292f79a2609927415df82e425a2e64a6f3c65cf5f9731357f2689"
         }
     }
 }


### PR DESCRIPTION
I tested locally and displays of user levels were numeric (0, 1, 2). On a new system, there would be no way for a CLI user to know the keywords are READER (0), USER (1) and ADMIN (2).  Also, AccessLevel was errantly spelled "AccessLeve".